### PR TITLE
Build using prebuilt python binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ __pycache__/
 *.pyc
 *.pyd
 
+# CMake
 CMakeUserPresets.json
-binaryCache
+cmake-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(cmake/CcpVendorUtilities.cmake)
 include(cmake/CcpTargetConfigurations.cmake)
 include(cmake/CcpDocsGenerator.cmake)
 
-find_package(Python3 COMPONENTS Development REQUIRED)
+find_package(Python3 COMPONENTS Development Interpreter REQUIRED)
 find_package(greenlet CONFIG REQUIRED)
 
 
@@ -64,16 +64,15 @@ set_target_properties(Scheduler PROPERTIES
 
 # Provide an install target iff this is the top level project only
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-
-    if (WIN32)
-        find_program(BUILT_PYTHON_EXECUTABLE python REQUIRED NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
-    elseif(APPLE)
-        find_program(BUILT_PYTHON_EXECUTABLE python3 REQUIRED NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
-    endif()
-
     get_target_property(GREENLET_IMPORTED_LOCATION Greenlet IMPORTED_LOCATION)
-    get_filename_component(PYTHON_TOOL_ROOT_DIR ${BUILT_PYTHON_EXECUTABLE} DIRECTORY)
     get_filename_component(GREENLET_IMPORTED_LOCATION_DIR ${GREENLET_IMPORTED_LOCATION} DIRECTORY)
+
+    # Store python path in environment for subsequent build steps
+    if(WIN32)
+        SET(ENV{PYTHONPATH} "${CMAKE_SOURCE_DIR}/python\;$<TARGET_FILE_DIR:Scheduler>\;${GREENLET_IMPORTED_LOCATION_DIR}/python\;${GREENLET_IMPORTED_LOCATION_DIR}")
+    elseif(APPLE)
+        SET(ENV{PYTHONPATH} "${CMAKE_SOURCE_DIR}/python:$<TARGET_FILE_DIR:Scheduler>:${GREENLET_IMPORTED_LOCATION_DIR}/python:${GREENLET_IMPORTED_LOCATION_DIR}")
+    endif()
 
     # Determine if/when to generate/build documentation. The rules are as follows:
     # - If running locally - Build documentation is OFF by default
@@ -87,21 +86,14 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     option(BUILD_DOCUMENTATION "Build Documentation" ${BUILD_DOCUMENTATION_DEFAULT_FLAG})
 
     if(BUILD_DOCUMENTATION)
-
-#        # Run sphinx
-        if(WIN32)
-            set(PYTHONPATH_ENV_SPHINX "${CMAKE_SOURCE_DIR}/python/\;$<TARGET_FILE_DIR:Scheduler>\;${PYTHON_TOOL_ROOT_DIR}/Lib\;${PYTHON_TOOL_ROOT_DIR}\;${GREENLET_IMPORTED_LOCATION_DIR}/python\;${GREENLET_IMPORTED_LOCATION_DIR}")
-        elseif(APPLE)
-            set(PYTHONPATH_ENV_SPHINX "${CMAKE_SOURCE_DIR}/python/:$<TARGET_FILE_DIR:Scheduler>:${PYTHON_TOOL_ROOT_DIR}:${GREENLET_IMPORTED_LOCATION_DIR}/python:${GREENLET_IMPORTED_LOCATION_DIR}")
-        endif()
-#
+        # Run sphinx
         set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/doc/source)
         set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/doc/build)
 
         create_carbon_docs_sphinx_target(
-                PYTHON_EXE ${BUILT_PYTHON_EXECUTABLE}
+                PYTHON_EXE ${Python3_EXECUTABLE}
                 VENV_NAME docs_generation_venv
-                PYTHONPATH_ENV ${PYTHONPATH_ENV_SPHINX}
+                PYTHONPATH_ENV $ENV{PYTHONPATH}
                 SPHINX_SOURCE ${SPHINX_SOURCE}
                 SPHINX_BUILD ${SPHINX_BUILD}
                 DOXYGEN_SRC_FILES ${SRC_FILES}
@@ -112,7 +104,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
         # Ensure that Scheduler is built before Spinx target
         add_dependencies(Sphinx Scheduler)
-
     endif()
 
     option(BUILD_TESTING "Build and run tests" ON)
@@ -122,13 +113,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         # Build test
         add_subdirectory(tests/capiTest)
 
-        if(WIN32)
-            set(ENV{PYTHONPATH} ${CMAKE_SOURCE_DIR}/python/\;${PYTHON_TOOL_ROOT_DIR}/Lib)
-        elseif(APPLE)
-            set(ENV{PYTHONPATH} ${CMAKE_SOURCE_DIR}/python/:${PYTHON_TOOL_ROOT_DIR}/Lib)
-        endif()
-
-        execute_process(COMMAND ${BUILT_PYTHON_EXECUTABLE} discover.py
+        execute_process(COMMAND ${Python3_EXECUTABLE} discover.py
                 OUTPUT_VARIABLE PYTHON_TESTS_STR
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 ERROR_STRIP_TRAILING_WHITESPACE
@@ -141,30 +126,24 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
             message(FATAL_ERROR "Error encountered during test discovery:\n=== stderr: ===\n${PYTHON_TEST_DISCOVERY_ERRORS}\n=== stdout: ===\n${PYTHON_TESTS_STR}")
         endif()
 
-        if(WIN32)
-            SET(PYTHONPATH_ENV "${CMAKE_SOURCE_DIR}/python/\;$<TARGET_FILE_DIR:Scheduler>\;${PYTHON_TOOL_ROOT_DIR}/Lib\;${PYTHON_TOOL_ROOT_DIR}\;${GREENLET_IMPORTED_LOCATION_DIR}/python\;${GREENLET_IMPORTED_LOCATION_DIR}")
-        elseif(APPLE)
-            SET(PYTHONPATH_ENV "${CMAKE_SOURCE_DIR}/python/:$<TARGET_FILE_DIR:Scheduler>:${PYTHON_TOOL_ROOT_DIR}/Lib:${PYTHON_TOOL_ROOT_DIR}:${GREENLET_IMPORTED_LOCATION_DIR}/python:${GREENLET_IMPORTED_LOCATION_DIR}")
-        endif()
-
         separate_arguments(PYTHON_TESTS UNIX_COMMAND ${PYTHON_TESTS_STR})
 
         foreach (PYTHON_TEST ${PYTHON_TESTS})
             message(STATUS "Found test ${PYTHON_TEST}")
             add_test(NAME ${PYTHON_TEST}
-                COMMAND ${BUILT_PYTHON_EXECUTABLE} -m unittest -v ${PYTHON_TEST}
+                COMMAND ${Python3_EXECUTABLE} -m unittest -v ${PYTHON_TEST}
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/python/scheduler/tests
             )
-            set_tests_properties(${PYTHON_TEST} PROPERTIES ENVIRONMENT "PYTHONPATH=${PYTHONPATH_ENV};BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>")
+            set_tests_properties(${PYTHON_TEST} PROPERTIES ENVIRONMENT "PYTHONPATH=$ENV{PYTHONPATH};BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>")
         endforeach ()
 
         set(ALL_PYTHON_TEST RunAllPythonTestsInSingleInterpreterSession)
         add_test(NAME ${ALL_PYTHON_TEST}
-            COMMAND ${BUILT_PYTHON_EXECUTABLE} -m unittest discover -v
+            COMMAND ${Python3_EXECUTABLE} -m unittest discover -v
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/python/scheduler/tests
             COMMAND_EXPAND_LISTS
         )
-        set_tests_properties(${ALL_PYTHON_TEST} PROPERTIES ENVIRONMENT "PYTHONPATH=${PYTHONPATH_ENV};BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>")
+        set_tests_properties(${ALL_PYTHON_TEST} PROPERTIES ENVIRONMENT "PYTHONPATH=$ENV{PYTHONPATH};BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>")
     endif()
 
     set(INSTALL_BIN_ONLY OFF CACHE BOOL "Do not Install configuration files meant to be read by projects using this project as a dependency (Cmake Config/ header files etc . . .). Set this to ON when installing this component to the perforce vendor folder")

--- a/doc/source/guides/howExceptionsAreManaged.rst
+++ b/doc/source/guides/howExceptionsAreManaged.rst
@@ -116,7 +116,7 @@ For further information on kill refer to :doc:`killingTasklets`.
    >>>Kill called
 
 Preventing uncaught exceptions from being raised on parent tasklets using :py:attr:`scheduler.tasklet.dont_raise`
------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------------------------
 
 Usually, (excluding TaskletExit exceptions) an uncaught exception on a child tasklet will result in that exception being raised on the parent tasklet. setting :py:attr:`scheduler.tasklet.dont_raise` to `True` before binding a tasklet will prevent this from happening.
 

--- a/tests/capiTest/CMakeLists.txt
+++ b/tests/capiTest/CMakeLists.txt
@@ -29,13 +29,6 @@ target_link_libraries(SchedulerCapiTest PRIVATE GTest::gtest GTest::gtest_main P
 
 # Generate paths Include for each config
 # Allows for easy use inside IDE
-
-if(WIN32)
-    set(PYTHON_STDLIB_PATH ${PYTHON_TOOL_ROOT_DIR}/Lib)
-elseif(APPLE)
-    set(PYTHON_STDLIB_PATH $<TARGET_FILE_DIR:Python3::Python>/python3.12)
-endif()
-
 file (GENERATE
     OUTPUT "PackagePaths_$<CONFIG>.h"
     CONTENT
@@ -44,19 +37,11 @@ file (GENERATE
 #include <string>
 std::wstring SCHEDULER_CEXTENSION_MODULE_PATH = L\"$<TARGET_FILE_DIR:Scheduler>\";
 std::wstring SCHEDULER_PACKAGE_PATH = L\"${CMAKE_SOURCE_DIR}/python\";
-std::wstring STDLIB_PATH = L\"${PYTHON_STDLIB_PATH}\";
+std::wstring STDLIB_PATH = L\"${Python3_STDLIB}\";
 std::wstring GREENLET_CEXTENSION_MODULE_PATH = L\"${GREENLET_IMPORTED_LOCATION_DIR}\";
 std::wstring GREENLET_MODULE_PATH = L\"${GREENLET_IMPORTED_LOCATION_DIR}/python\";
 "
 )
-
-# Copy the python dll to target build directory
-if(WIN32)
-    set(PythonLibName "python312.dll")
-elseif(APPLE)
-    set(PythonLibName "libpython3.12.dylib")
-endif()
-
 
 cmake_policy(SET CMP0175 OLD) # Allows us to use OUTPUT with PRE_BUILD in add_custom_command
 add_custom_command (
@@ -76,21 +61,9 @@ if (APPLE)
     add_custom_command(
             TARGET SchedulerCapiTest POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
-            $<TARGET_FILE_DIR:Python3::Python>/${PythonLibName}
-            $<TARGET_FILE_DIR:SchedulerCapiTest>)
-
-    gtest_discover_tests(
-            SchedulerCapiTest capiTests
-            DISCOVERY_MODE PRE_TEST
-            WORKING_DIRECTORY ${PYTHON_TOOL_ROOT_DIR}
+            $<TARGET_FILE:Python3::Python>
+            $<TARGET_FILE_DIR:SchedulerCapiTest>
     )
-
-elseif (WIN32)
-    add_custom_command(
-            TARGET SchedulerCapiTest POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy
-            ${PYTHON_TOOL_ROOT_DIR}/${PythonLibName}
-            $<TARGET_FILE_DIR:SchedulerCapiTest>)
 
     gtest_discover_tests(
             SchedulerCapiTest capiTests
@@ -98,7 +71,19 @@ elseif (WIN32)
             WORKING_DIRECTORY $<TARGET_FILE_DIR:Python3::Python>
     )
 
+elseif (WIN32)
+    add_custom_command(
+            TARGET SchedulerCapiTest POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_RUNTIME_DLLS:SchedulerCapiTest>
+            $<TARGET_FILE_DIR:SchedulerCapiTest>
+            COMMAND_EXPAND_LISTS
+            VERBATIM
+    )
+
+    gtest_discover_tests(
+            SchedulerCapiTest capiTests
+            DISCOVERY_MODE PRE_TEST
+            WORKING_DIRECTORY $<TARGET_FILE_DIR:Python3::Python>
+    )
 endif ()
-
-
-

--- a/tests/capiTest/CMakeLists.txt
+++ b/tests/capiTest/CMakeLists.txt
@@ -68,7 +68,6 @@ if (APPLE)
     gtest_discover_tests(
             SchedulerCapiTest capiTests
             DISCOVERY_MODE PRE_TEST
-            WORKING_DIRECTORY $<TARGET_FILE_DIR:Python3::Python>
     )
 
 elseif (WIN32)
@@ -84,6 +83,5 @@ elseif (WIN32)
     gtest_discover_tests(
             SchedulerCapiTest capiTests
             DISCOVERY_MODE PRE_TEST
-            WORKING_DIRECTORY $<TARGET_FILE_DIR:Python3::Python>
     )
 endif ()

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,8 +8,8 @@
     {
       "kind": "git",
       "repository": "git@github.com:ccpgames/carbon-vcpkg-registry.git",
-      "baseline": "9332c0f3559986c2d8671dbf79510d094844ec13",
-      "packages": ["carbon-*", "greenlet", "python3", "ccp-debug-info"]
+      "baseline": "4089428d25208720dcf6451cb8b57816bbf9fb9d",
+      "packages": ["carbon-*", "greenlet", "python3-prebuilt", "ccp-debug-info"]
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "dependencies": [
     {
-      "name": "python3",
-      "version>=": "3.12.3"
+      "name": "python3-prebuilt",
+      "version>=": "3.12.3#1"
     },
     {
       "name": "greenlet",
-      "version>=": "3.0.3#1"
+      "version>=": "3.0.3#4"
     },
     {
       "name": "gtest",


### PR DESCRIPTION
This PR contains changes required to build `Scheduler` using prebuilt python binaries. These are universal binaries on macOS.