### PR TITLE
Update python3-prebuilt to ´3.12.3#2´

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "python3-prebuilt",
-      "version>=": "3.12.3#1"
+      "version>=": "3.12.3#2"
     },
     {
       "name": "greenlet",


### PR DESCRIPTION
This PR updates python3-prebuilt to version 3.12.3#2, bringing the dependency in line with the port manifest.