### PR TITLE
force release version of greenlet

### DIFF
--- a/cmake/triplets/universal-osx-carbon.cmake
+++ b/cmake/triplets/universal-osx-carbon.cmake
@@ -3,3 +3,7 @@ set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES "arm64;x86_64")
+
+if (PORT MATCHES "greenlet")
+    set(VCPKG_BUILD_TYPE release)
+endif()


### PR DESCRIPTION
I have a suspicion that the failing builds on CI have to do with greenlet attempting to link against the debug build of python . . . this is an experiment 