### PR TITLE
Update greenlet to `3.0.3#6`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,15 +164,17 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         )
         install(FILES ${GREENLET_IMPORTED_LOCATION} DESTINATION bin/)
     else()
+        install(
+                TARGETS Scheduler
+                EXPORT SchedulerTargets
+                CONFIGURATIONS Release
+                RUNTIME DESTINATION bin/
+                ARCHIVE DESTINATION lib/
+                LIBRARY DESTINATION lib/
+        )
         # Install rule to ensure that our runtime and linker files are in the expected, platform-specific folders
         install(DIRECTORY include DESTINATION . FILES_MATCHING PATTERN "*.h")
-        install(FILES python/scheduler/__init__.py DESTINATION bin/python/scheduler/)
-
-        if(WIN32)
-            install(FILES $<TARGET_FILE_DIR:Scheduler>/_scheduler.pyd DESTINATION bin/)
-        elseif(APPLE)
-            install(FILES $<TARGET_FILE_NAME:Scheduler>  DESTINATION bin/)
-        endif()
+        install(DIRECTORY python/scheduler DESTINATION bin/python FILES_MATCHING PATTERN "*.py")
 
         install(FILES carbon-schedulerConfig.cmake DESTINATION ${CMAKE_INSTALL_PREFIX}/share/carbon-scheduler/)
     endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "greenlet",
-      "version>=": "3.0.3#5"
+      "version>=": "3.0.3#6"
     },
     {
       "name": "gtest",


### PR DESCRIPTION
This PR updates greenlet to `3.0.3#6` which fixes a build failure on macOS where greenlet was building against a system installation of python.