### PR TITLE
Configure CMAKE_MODULE_LINKER_FLAGS_\${CONFIG}

### DIFF
--- a/cmake/CcpBuildConfigurations.cmake
+++ b/cmake/CcpBuildConfigurations.cmake
@@ -52,6 +52,10 @@ function(create_new_build_config config prototype)
         ${CMAKE_EXE_LINKER_FLAGS_${PROTOTYPE}} CACHE STRING
         "Flags used for linking binaries during ${config} builds."
         FORCE)
+    set(CMAKE_MODULE_LINKER_FLAGS_${CONFIG}
+        ${CMAKE_MODULE_LINKER_FLAGS_${PROTOTYPE}} CACHE STRING
+        "Flags used for linking modules during ${config} builds."
+        FORCE)
     set(CMAKE_SHARED_LINKER_FLAGS_${CONFIG}
         ${CMAKE_SHARED_LINKER_FLAGS_${PROTOTYPE}} CACHE STRING
         "Flags used by the shared libraries linker during ${config} builds."
@@ -60,7 +64,8 @@ function(create_new_build_config config prototype)
         CMAKE_CXX_FLAGS_${CONFIG}
         CMAKE_C_FLAGS_${CONFIG}
         CMAKE_EXE_LINKER_FLAGS_${CONFIG}
-        CMAKE_SHARED_LINKER_FLAGS_${CONFIG})
+        CMAKE_SHARED_LINKER_FLAGS_${CONFIG}
+        CMAKE_MODULE_LINKER_FLAGS_${CONFIG})
 endfunction()
 
 create_new_build_config(Internal Release)


### PR DESCRIPTION
Because we are building carbon-scheduler as a cmake `MODULE`, we need to set `CMAKE_MODULE_LINKER_FLAGS_*` for each build flavour.

https://github.com/carbonengine/scheduler/blob/ad4937bf68d601f888f205fe4ad6da88f351b939/CMakeLists.txt#L40