### PR TITLE
Store test build flavour in cmake configured header file

### DIFF
--- a/tests/capiTest/CMakeLists.txt
+++ b/tests/capiTest/CMakeLists.txt
@@ -44,6 +44,7 @@ std::wstring SCHEDULER_PACKAGE_PATH = L\"${CMAKE_SOURCE_DIR}/python\";
 std::wstring STDLIB_PATH = L\"${Python3_STDLIB}\";
 std::wstring GREENLET_CEXTENSION_MODULE_PATH = L\"${GREENLET_IMPORTED_LOCATION_DIR}\";
 std::wstring GREENLET_MODULE_PATH = L\"${GREENLET_IMPORTED_LOCATION_DIR}/python\";
+const char* BUILD_FLAVOUR = \"$<LOWER_CASE:$<CONFIG>>\";
 "
 )
 
@@ -87,7 +88,5 @@ elseif (WIN32)
     gtest_discover_tests(
             SchedulerCapiTest capiTests
             DISCOVERY_MODE PRE_TEST
-            PROPERTIES
-                ENVIRONMENT "BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>"
     )
 endif ()

--- a/tests/capiTest/InterpreterWithSchedulerModule.cpp
+++ b/tests/capiTest/InterpreterWithSchedulerModule.cpp
@@ -281,21 +281,19 @@ void InterpreterWithSchedulerModule::SetUp()
 #define strcasecmp _stricmp
 #endif
 
-	const char* buildflavor = std::getenv( "BUILDFLAVOR" );
-
-	if( strcasecmp( buildflavor, "release" ) == 0 )
+	if( strcasecmp( BUILD_FLAVOUR, "release" ) == 0 )
 	{
 		m_schedulerModule = PyImport_ImportModule( "_scheduler" );
 	}
-	else if( strcasecmp( buildflavor, "internal" ) == 0 )
+	else if( strcasecmp( BUILD_FLAVOUR, "internal" ) == 0 )
 	{
 		m_schedulerModule = PyImport_ImportModule( "_scheduler_internal" );
 	}
-	else if( strcasecmp( buildflavor, "trinitydev" ) == 0 )
+	else if( strcasecmp( BUILD_FLAVOUR, "trinitydev" ) == 0 )
 	{
 		m_schedulerModule = PyImport_ImportModule( "_scheduler_trinitydev" );
 	}
-	else if( strcasecmp( buildflavor, "debug" ) == 0 )
+	else if( strcasecmp( BUILD_FLAVOUR, "debug" ) == 0 )
 	{
 		m_schedulerModule = PyImport_ImportModule( "_scheduler_debug" );
 	}


### PR DESCRIPTION
On MacOS, environment variables passed to `gtest_discover_tests` through the `PROPERTIES` parameter, do not appear in the running test.

This has been causing scheduler tests to fail on macOS since this change:  https://github.com/carbonengine/scheduler/commit/5ffd483b9d286af5e1a457683af9b26157a9e667

As we already configure a per-configuration header file, I have replaced the environment variable with a `const char* BUILD_FLAVOUR ...` in `PackagePaths_$<CONFIG>.h`