### PR TITLE
Fix macos gtests

### DIFF
--- a/tests/capiTest/CMakeLists.txt
+++ b/tests/capiTest/CMakeLists.txt
@@ -60,23 +60,7 @@ add_custom_command (
 add_custom_target(GeneratePackagePathsHeader DEPENDS "PackagePaths.h")
 add_dependencies(SchedulerCapiTest GeneratePackagePathsHeader)
 
-
-if (APPLE)
-    add_custom_command(
-            TARGET SchedulerCapiTest POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy
-            $<TARGET_FILE:Python3::Python>
-            $<TARGET_FILE_DIR:SchedulerCapiTest>
-    )
-
-    gtest_discover_tests(
-            SchedulerCapiTest capiTests
-            DISCOVERY_MODE PRE_TEST
-            PROPERTIES
-                ENVIRONMENT "BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>"
-    )
-
-elseif (WIN32)
+if (WIN32)
     add_custom_command(
             TARGET SchedulerCapiTest POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
@@ -85,11 +69,10 @@ elseif (WIN32)
             COMMAND_EXPAND_LISTS
             VERBATIM
     )
-
-    gtest_discover_tests(
-            SchedulerCapiTest capiTests
-            DISCOVERY_MODE PRE_TEST
-            PROPERTIES
-                ENVIRONMENT "BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>"
-    )
 endif ()
+gtest_discover_tests(
+        SchedulerCapiTest capiTests
+        DISCOVERY_MODE PRE_TEST
+        PROPERTIES
+        ENVIRONMENT "BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>"
+)

--- a/tests/capiTest/CMakeLists.txt
+++ b/tests/capiTest/CMakeLists.txt
@@ -72,6 +72,8 @@ if (APPLE)
     gtest_discover_tests(
             SchedulerCapiTest capiTests
             DISCOVERY_MODE PRE_TEST
+            PROPERTIES
+                ENVIRONMENT "BUILDFLAVOR=$<LOWER_CASE:$<CONFIG>>"
     )
 
 elseif (WIN32)


### PR DESCRIPTION
- Fix an issue where the `BUILDFLAVOR` environment variable was not being set for gtests on maocs
- Simplify testing by:
  - only having one call to `gtest_discover_tests` 
  - not copying any dependencies to the test target dir on macOS, this was being done based on a missunderstanding with how dylibs were being loaded on macOS.