### PR TITLE
upgrade python dependency from 3.12.3#2 to 3.12.3#3

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "python3-prebuilt",
-      "version>=": "3.12.3#2"
+      "version>=": "3.12.3#3"
     },
     {
       "name": "greenlet",


### PR DESCRIPTION
Scheduler is building with an earlier port version than other carbon components. This might be causing the issue we are seeing with crashes inside scheduler on Intel MacOS machines