### PR TITLE
Reduce version of CMake required to build scheduler to 3.30.1 (latest version supported by VCPKG)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,8 +2,8 @@
   "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 30,
-    "patch": 1
+    "minor": 31,
+    "patch": 0
   },
   "configurePresets": [
     {


### PR DESCRIPTION
I've been starting to notice errors where VCPKG will fail to build dependencies due to it not having the required cmake version.

This version matches that in the vcpkg-tools.json file in vcpkg:
https://github.com/microsoft/vcpkg/blob/a62ce77d56ee07513b4b67de1ec2daeaebfae51a/scripts/vcpkg-tools.json#L23-L70

I've lowered the version in CMakePresets.json file to match, so that the same version of cmake is required to build scheduler through vcpkg & as a top level project