### PR TITLE
fix(tasklet): release the PyGreenlet_Switch return reference

### DIFF
--- a/src/Tasklet.cpp
+++ b/src/Tasklet.cpp
@@ -398,7 +398,9 @@ bool Tasklet::SwitchTo( )
 
         m_firstRun = false;
 
-		ret = PyGreenlet_Switch( m_greenlet, args, kwargs );
+		PyObject* switchResult = PyGreenlet_Switch( m_greenlet, args, kwargs );
+		ret = ( switchResult != nullptr );
+		Py_XDECREF( switchResult );
 
         // Clear arguments
 		SetArguments( nullptr );


### PR DESCRIPTION
## Summary
Fixes a reference leak on the hottest scheduler path.

## Problem
`PyGreenlet_Switch` returns a new reference to the switched-in value, but
it was assigned straight into a `bool`. The object was never released,
leaking a reference on every tasklet switch and growing memory unbounded
over server uptime.

## Fix
Capture the result into a `PyObject*`, derive the success bool from it,
and `Py_XDECREF` it. No semantic change — the code only ever used the
boolean meaning of the result.

## Type
Performance / stability — memory leak on the critical path (Critical;
whole-shard blast radius).

## Testing
Manual review; control flow (`if(!ret)`, `return ret`) preserved.