### PR TITLE
Use new `CcpColor` enum

### DIFF
--- a/src/ScheduleManager.cpp
+++ b/src/ScheduleManager.cpp
@@ -374,7 +374,7 @@ bool ScheduleManager::Yield()
 
 bool ScheduleManager::RunTaskletsForTime( long long timeout )
 {
-	TelemetryZone telemetryZone(TMCM_CPP, "ScheduleManager::RunTaskletsForTime()", __FILE__, __LINE__, tracy::Color::LightGreen);
+	TelemetryZone telemetryZone(TMCM_CPP, "ScheduleManager::RunTaskletsForTime()", __FILE__, __LINE__, CcpColor::LightGreen);
 	s_numberOfTaskletsCompletedLastRunWithTimeout = 0;
 
     s_numberOfTaskletsSwitchedLastRunWithTimeout = 0;
@@ -402,7 +402,7 @@ bool ScheduleManager::RunTaskletsForTime( long long timeout )
 
 bool ScheduleManager::RunNTasklets( int n )
 {
-	TelemetryZone telemetryZone(TMCM_CPP, "ScheduleManager::RunNTasklets()", __FILE__, __LINE__, tracy::Color::LightGreen);
+	TelemetryZone telemetryZone(TMCM_CPP, "ScheduleManager::RunNTasklets()", __FILE__, __LINE__, CcpColor::LightGreen);
     m_taskletLimit = n;
 
     m_runType = RunType::TASKLET_LIMITED;
@@ -420,7 +420,7 @@ bool ScheduleManager::RunNTasklets( int n )
 
 bool ScheduleManager::Run( Tasklet* startTasklet /* = nullptr */ )
 {
-	TelemetryZone telemetryZone(TMCM_CPP, "ScheduleManager::Run()", __FILE__, __LINE__, tracy::Color::LightGreen);
+	TelemetryZone telemetryZone(TMCM_CPP, "ScheduleManager::Run()", __FILE__, __LINE__, CcpColor::LightGreen);
     Tasklet* baseTasklet = nullptr;
 
     Tasklet* endTasklet = nullptr;

--- a/src/Tasklet.cpp
+++ b/src/Tasklet.cpp
@@ -197,7 +197,7 @@ void Tasklet::Uninitialise()
 
 bool Tasklet::Insert()
 {
-	TelemetryZone telemetryZone(TMCM_CPP, "Tasklet::Insert()", __FILE__, __LINE__, tracy::Color::LightGreen);
+	TelemetryZone telemetryZone(TMCM_CPP, "Tasklet::Insert()", __FILE__, __LINE__, CcpColor::LightGreen);
     if ( m_blocked )
     {
 		PyErr_SetString( PyExc_RuntimeError, "Failed to insert tasklet: Cannot insert blocked tasklet" );
@@ -222,7 +222,7 @@ bool Tasklet::Insert()
 
 bool Tasklet::SwitchImplementation()
 {
-	TelemetryZone telemetryZone(TMCM_CPP, "Tasklet::SwitchImplementation()", __FILE__, __LINE__, tracy::Color::LightGreen);
+	TelemetryZone telemetryZone(TMCM_CPP, "Tasklet::SwitchImplementation()", __FILE__, __LINE__, CcpColor::LightGreen);
 	// Remove the calling tasklet
 	if( !m_alive )
 	{


### PR DESCRIPTION
`core` no longer forwards the 'tracy' dependency. Instead, it provides a new enum to use.